### PR TITLE
use a ternary assignment for query portion

### DIFF
--- a/lib/recipes/css.js
+++ b/lib/recipes/css.js
@@ -101,7 +101,7 @@ var CSS = {
         data: [{data: css, path: last.path, urls: deps}]
       };
     });
-    
+
     return source._cssExpansion = wake.target(null, imports.concat(proxy), function(deps) {
       return {data: self.reduce(deps)};
     });
@@ -118,7 +118,7 @@ var CSS = {
 
       if (!pth) return match;
 
-      query      = pth.match(QUERY)[0] || '';
+      query      = pth.match(QUERY) ? pth.match(QUERY)[0] : '';
       target     = wake.target(pth.replace(QUERY, '')).targetClosestTo(pathname);
       targetPath = target.unhashify();
 


### PR DESCRIPTION
to avoid calling `[0]` on `null` when `pth.match(QUERY)` doesn't match anything. 

It looks like your last patch for query strings caused this to happen for `url()`s in css with no querystrings. Are there tests I should run?
