### PR TITLE
catch JS_Parse_Errors in uglify processor

### DIFF
--- a/lib/processors/uglify.js
+++ b/lib/processors/uglify.js
@@ -9,10 +9,21 @@ var bundle = function(pathname, sources, options) {
 
   if (options.sourceMap !== false) {
     ast = sources.reduce(function(toplevel, source) {
-      return uglify.parse(source.data, {
-        filename: path.relative(path.dirname(pathname), source.path),
-        toplevel: toplevel
-      });
+      var filename = path.relative(path.dirname(pathname), source.path);
+      try {
+        return uglify.parse(source.data, {
+          filename: filename,
+          toplevel: toplevel
+        });
+      } catch(error) {
+        if (error instanceof uglify.JS_Parse_Error) {
+          console.error("Parse error at " + filename + ":" + error.line + "," + error.col);
+          console.error(error.message);
+          console.error(error.stack);
+          process.exit(1);
+        }
+        throw error;
+      }
     }, ast);
   } else {
     code     = concat(sources, options);


### PR DESCRIPTION
...and output a useful message to the console.

I've been working with wake a lot recently for a static site with assets built by wake. I was using Guard and a Makefile to build files from a `src` directory into a `dist` directory while I edited code. One of the Makefile steps is to build the assets with wake. I serve the dist folder with `python -m SimpleHTTPServer` while I edit stuff in src.

The thing that got annoying was that if I introduced syntax errors into my javascript, I'd get an unhelpful message in my Guard console similar to this (see https://github.com/dwo/wake-example-1 to reproduce):

```
> wake-example-1@0.0.1 wake /Users/robin/source/wake-example-1
> wake


/Users/robin/source/wake-example-1/node_modules/wake/node_modules/uglify-js/lib/parse.js:197
    throw new JS_Parse_Error(message, line, col, pos);
          ^
Error
    at new JS_Parse_Error (/Users/robin/source/wake-example-1/node_modules/wake/node_modules/uglify-js/lib/parse.js:189:18)
    at js_error (/Users/robin/source/wake-example-1/node_modules/wake/node_modules/uglify-js/lib/parse.js:197:11)
    at croak (/Users/robin/source/wake-example-1/node_modules/wake/node_modules/uglify-js/lib/parse.js:656:9)
    at token_error (/Users/robin/source/wake-example-1/node_modules/wake/node_modules/uglify-js/lib/parse.js:664:9)
    at expect_token (/Users/robin/source/wake-example-1/node_modules/wake/node_modules/uglify-js/lib/parse.js:677:9)
    at expect (/Users/robin/source/wake-example-1/node_modules/wake/node_modules/uglify-js/lib/parse.js:680:36)
    at /Users/robin/source/wake-example-1/node_modules/wake/node_modules/uglify-js/lib/parse.js:1195:44
    at /Users/robin/source/wake-example-1/node_modules/wake/node_modules/uglify-js/lib/parse.js:703:24
    at expr_atom (/Users/robin/source/wake-example-1/node_modules/wake/node_modules/uglify-js/lib/parse.js:1152:35)
    at maybe_unary (/Users/robin/source/wake-example-1/node_modules/wake/node_modules/uglify-js/lib/parse.js:1327:19)
npm ERR! weird error 8
npm ERR! not ok code 
```

So I went looking for a reasonable way of catching these errors, and came across https://github.com/mishoo/UglifyJS2/blob/v2.4.15/bin/uglifyjs#L276-L290

If I apply the same try/catch to wake's uglify processor, the command line gives a much more helpful message:

```
Parse error at ../src/syntax_fail.js:10,2
Unexpected token name «derp», expected punc «,»
```

WDYT? 
