### PR TITLE
Fixed sourceMappingURL comment for IE

### DIFF
--- a/lib/recipes/javascript.js
+++ b/lib/recipes/javascript.js
@@ -39,7 +39,7 @@ var JavaScript = {
           code = data.code;
 
       if (settings.sourceMap !== false)
-        code += '\n//@ sourceMappingURL=' + data.mapPath;
+        code += '\n//# sourceMappingURL=' + data.mapPath;
 
       return {
         data:   new Buffer(code, 'utf8'),


### PR DESCRIPTION
Hi, currently used sourceMap syntax
`\n//@ sourceMappingURL=`
seems to break IE causing call to undefined  (here is more info on this problem: https://github.com/mishoo/UglifyJS2/issues/108)

I think that this faye's ticket also mentions this problem https://github.com/faye/faye/issues/272
