### PR TITLE
catch the other potential JS_Parse_Error too

### DIFF
--- a/lib/processors/uglify.js
+++ b/lib/processors/uglify.js
@@ -28,7 +28,17 @@ var bundle = function(pathname, sources, options) {
   } else {
     code     = concat(sources, options);
     codeHash = digest.hash(code);
-    ast      = uglify.parse(code);
+    try {
+      ast = uglify.parse(code);
+    } catch(error) {
+      if (error instanceof uglify.JS_Parse_Error) {
+        console.error("Parse error at " + filename + ":" + error.line + "," + error.col);
+        console.error(error.message);
+        console.error(error.stack);
+        process.exit(1);
+      }
+      throw error;
+    }
   }
 
   if (options.minify === false) return {code: code, codeHash: codeHash};


### PR DESCRIPTION
I didn't catch this one with the first pull request I sent (and only noticed when I turned off source maps). I thought perhaps you'd think of a better way to re-use the error handling code than I would.
