### PR TITLE
support clean-css 3+

### DIFF
--- a/lib/processors/clean.js
+++ b/lib/processors/clean.js
@@ -2,11 +2,11 @@ var Clean = require('clean-css');
 
 module.exports = {
   minify: function(css) {
-    if (typeof Clean.process === 'function') {
+    if (typeof Clean.process === 'function') { // clean-css 1.x
       return Clean.process(css);
     } else {
       var minified = new Clean().minify(css);
-      if (typeof minified === 'string')
+      if (typeof minified === 'string') // clean-css 2.x
         return minified;
       else // clean-css 3+
         return minified.styles;

--- a/lib/processors/clean.js
+++ b/lib/processors/clean.js
@@ -2,9 +2,13 @@ var Clean = require('clean-css');
 
 module.exports = {
   minify: function(css) {
-    if (typeof Clean.process === 'function')
+    if (typeof Clean.process === 'function') {
       return Clean.process(css);
-    else
-      return new Clean().minify(css);
+    } else {
+      var minified = new Clean().minify(css);
+      if (typeof minified === 'string')
+        return minified;
+      else // clean-css 3+
+        return minified.styles;
   }
 };


### PR DESCRIPTION
the clean-css interface changed between v2.2 and v3: 

> minify method returns a hash instead of a string now, so use new CleanCSS().minify(source).styles instead of new CleanCSS().minify(source).
